### PR TITLE
added response.sendStatus(200) to handlePaymentSuccess so that stripe…

### DIFF
--- a/src/api/v1.js
+++ b/src/api/v1.js
@@ -223,6 +223,7 @@ function handlePaymentStatus(request, response, next) {
       if (intent.payment_status === 'paid') {
         checkoutSessionCompleted(intent);
       }
+      response.sendStatus(200);
       break;
   }
 


### PR DESCRIPTION
…s checkout.session.complete hook stops reporting as failed